### PR TITLE
Eliminate products logic

### DIFF
--- a/app/controllers/deals_controller.rb
+++ b/app/controllers/deals_controller.rb
@@ -43,19 +43,23 @@ class DealsController < ApplicationController
   def complete
     @deal.status = "completed"
     @deal.save
+    # Hide items after a deal is completed
     @items = [@deal.offered_item, @deal.requested_item]
     @items.each do |item|
-      item.update(hidden: true) if item.category.name != "Servicios"
+      if item.category.name != "Servicios"
+        item.update(hidden: true)
+        # Cancel offers related to an item that's hidden after a deal is completed
+        offers = Offer.where(offered_item: item)
+        offers.update_all(status: "canceled") if offers.any?
+
+        requests = Offer.where(requested_item: item)
+        requests.update_all(status: "canceled") if requests.any?
+
+        # Cancel deals related to an item that's hidden after a deal is completed
+        deals = Deal.joins(:offer).where.not(status: 'completed').where("offers.offered_item_id = ? OR offers.requested_item_id = ?", item.id, item.id)
+        deals.update_all(status: "canceled") if deals.any?
+      end
     end
-    @offers = []
-    @items.each do |item|
-      @offers << item.requested_offers.where(status: "pending") if item.category.name != "Servicios"
-      @offers << item.offered_offers.where(status: "pending") if item.category.name != "Servicios"
-    end
-    @offers.each do |offer|
-      offer.update(status: "canceled")
-    end
-    
     redirect_to deals_path
   end
 

--- a/app/controllers/deals_controller.rb
+++ b/app/controllers/deals_controller.rb
@@ -47,6 +47,15 @@ class DealsController < ApplicationController
     @items.each do |item|
       item.update(hidden: true) if item.category.name != "Servicios"
     end
+    @offers = []
+    @items.each do |item|
+      @offers << item.requested_offers.where(status: "pending") if item.category.name != "Servicios"
+      @offers << item.offered_offers.where(status: "pending") if item.category.name != "Servicios"
+    end
+    @offers.each do |offer|
+      offer.update(status: "canceled")
+    end
+    
     redirect_to deals_path
   end
 

--- a/app/controllers/deals_controller.rb
+++ b/app/controllers/deals_controller.rb
@@ -45,7 +45,7 @@ class DealsController < ApplicationController
     @deal.save
     @items = [@deal.offered_item, @deal.requested_item]
     @items.each do |item|
-      item.update(hidden: true) if item.category != "Servicios"
+      item.update(hidden: true) if item.category.name != "Servicios"
     end
     redirect_to deals_path
   end

--- a/app/controllers/deals_controller.rb
+++ b/app/controllers/deals_controller.rb
@@ -43,6 +43,10 @@ class DealsController < ApplicationController
   def complete
     @deal.status = "completed"
     @deal.save
+    @items = [@deal.offered_item, @deal.requested_item]
+    @items.each do |item|
+      item.update(hidden: true) if item.category != "Servicios"
+    end
     redirect_to deals_path
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,6 +6,7 @@ class Item < ApplicationRecord
   has_many :requested_offers, class_name: 'Offer', foreign_key: 'requested_item_id'
   has_many :offered_offers, class_name: 'Offer', foreign_key: 'offered_item_id'
   has_many :offered_items, through: :offered_offers, source: :requested_item
+  
 
 
   validates :name, :description, :address, presence: true


### PR DESCRIPTION
Added logic to the Deals controller to:

- when a deal is completed, the items involved gets hidden unless the category of such items is "Servicios" (as servicios is re usable)
- Offers related to such items get cancelled.
- Deals related to such items get cancelled, unless they have been already completed.
