### PR TITLE
Privacy hide email

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -3,12 +3,14 @@ class OffersController < ApplicationController
 
   def show
     @reviewed_user = @offer.user_offerer == current_user ? @offer.user_requested : @offer.user_offerer
+
     @reviews = Review.where(user_reviewed: @reviewed_user)
     @rating = @reviews.average(:rating).round(2) if @reviews.any?
     @deal = Deal.new
     @chatroom = Chatroom.new
     authorize @offer
   end
+
 
 
   def create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,5 @@ class User < ApplicationRecord
   def deals
     offered_deals.or(Deal.where(id: received_deals))
   end
+
 end

--- a/app/views/chatrooms/_chats.html.erb
+++ b/app/views/chatrooms/_chats.html.erb
@@ -1,6 +1,6 @@
 <div class='container m-3 rounded-4'>
   <% @chatrooms.sort_by{|chatroom| chatroom.messages.last.created_at}.reverse.each do |chatroom| %>
-    <% other_users = chatroom.users.where.not(id: current_user.id) %>
+    <% user_name = chatroom.participants.where.not(user: current_user).first.user.nickname.nil? ? chatroom.participants.where.not(user: current_user).first.user.email.split('@').first : chatroom.participants.where.not(user: current_user).first.user.nickname%>
     <%= link_to chatroom, class: 'text-decoration-none', style: 'color: inherit;' do %>
       <div class='border p-3 my-2 bg-primary-dark rounded-4'>
         <p class='text-end text-muted'><%= chatroom.messages.last.created_at.strftime('%Y-%m-%d %H:%M:%S') if chatroom.messages.last %></p>
@@ -10,7 +10,7 @@
         <% else %>
           <p class='text-end text-muted'><i class="fa-regular fa-envelope-open"></i></p>
         <% end %>
-        <p class="mb-1"><strong><%= other_users.map(&:email).join(', ') %></strong> </p>
+        <p class="mb-1"><strong><%= user_name %></strong> </p>
         <hr class="my-2">
         <p class="mb-0"><%= chatroom.messages.last.content if chatroom.messages.last %></p>
       </div>

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -1,8 +1,8 @@
 <div class="container chatroom bg-primary"
   data-controller="chatroom-subscription"
-  data-chatroom-subscription-chatroom-id-value="<%= @chatroom.id %>"
->
-  <p class="text-center pt-3"><strong> Bienvenido a tu chat con <%= @chatroom.participants.where.not(user: current_user).first.user.nickname %></strong></p>
+  data-chatroom-subscription-chatroom-id-value="<%= @chatroom.id %>">
+  <% user_name = @chatroom.participants.where.not(user: current_user).first.user.nickname.nil? ? @chatroom.participants.where.not(user: current_user).first.user.email.split('@').first : @chatroom.participants.where.not(user: current_user).first.user.nickname%>
+  <p class="text-center pt-3"><strong> Bienvenido a tu chat con <%= user_name %></strong></p>
   <div class="messages" data-chatroom-subscription-target="messages">
     <% @chatroom.messages.each do |message| %>
       <%= render "messages/message", message: message %>

--- a/app/views/deals/_cards.html.erb
+++ b/app/views/deals/_cards.html.erb
@@ -7,17 +7,11 @@
       <span class="text-danger fw-bold"> Cancelado </span>
     <% elsif exchange.status == 'pending' %>
       <% if exchange.user_requested == current_user %>
-        <%if !exchange.user_offerer.nickname.nil?%>
-          <span><%= "#{exchange.user_offerer.nickname} te envio una oferta!" %></span>
-        <%else%>
-          <span><%= "#{exchange.user_offerer.email.split("@").first} te envio una oferta!" %></span>
-        <%end%>
+        <%offerer_name = exchange.user_offerer.nickname.nil? ? exchange.user_offerer.email.split("@").first : exchange.user_offerer.nickname %>
+        <span><%= "#{offerer_name} te envio una oferta!" %></span>
       <% else %>
-        <%if !exchange.user_requested.nickname.nil?%>
-          <span><%= "#{exchange.user_requested.nickname} te envio una oferta!" %></span>
-        <%else%>
-          <span><%= "Esperando la confirmacion de #{exchange.user_requested.email.split("@").first}..." %></span>
-        <%end%>
+        <%user_requested_name = exchange.user_requested.nickname.nil? ? exchange.user_requested.email.split("@").first : exchange.user_requested.nickname %>
+        <span><%= "#{user_requested_name} te envio una oferta!" %></span>
       <% end %>
     <% else %>
       <span class="text-warning fw-bold"> Pendiente </span>

--- a/app/views/deals/_cards.html.erb
+++ b/app/views/deals/_cards.html.erb
@@ -7,9 +7,17 @@
       <span class="text-danger fw-bold"> Cancelado </span>
     <% elsif exchange.status == 'pending' %>
       <% if exchange.user_requested == current_user %>
-        <span><%= "#{exchange.user_offerer.email} te envio una oferta!" %></span>
+        <%if !exchange.user_offerer.nickname.nil?%>
+          <span><%= "#{exchange.user_offerer.nickname} te envio una oferta!" %></span>
+        <%else%>
+          <span><%= "#{exchange.user_offerer.email.split("@").first} te envio una oferta!" %></span>
+        <%end%>
       <% else %>
-        <span><%= "Esperando la confirmacion de #{exchange.user_requested.email}..." %></span>
+        <%if !exchange.user_requested.nickname.nil?%>
+          <span><%= "#{exchange.user_requested.nickname} te envio una oferta!" %></span>
+        <%else%>
+          <span><%= "Esperando la confirmacion de #{exchange.user_requested.email.split("@").first}..." %></span>
+        <%end%>
       <% end %>
     <% else %>
       <span class="text-warning fw-bold"> Pendiente </span>

--- a/app/views/deals/_show_reviews.html.erb
+++ b/app/views/deals/_show_reviews.html.erb
@@ -3,12 +3,14 @@
   <% if reviewed_user == current_user %>
     <div class='' data-action='click->toggle-user-reviews#showreviews'><button class='btn btn-info p-3 my-2'>Reseñas recibidas: </button></div>
   <% else %>
-    <div class='' data-action='click->toggle-user-reviews#showreviews'><button class='btn btn-info p-3 my-2'>Reseñas de <%= reviewed_user.nickname %>: </button></div>
+    <% reviewed_name = reviewed_user.nickname.nil? ? reviewed_user.email.split("@").first : reviewed_user.nickname %>
+    <div class='' data-action='click->toggle-user-reviews#showreviews'><button class='btn btn-info p-3 my-2'>Reseñas de <%= reviewed_name %>: </button></div>
   <% end %>
   <div class="col-6 col-md-4 d-none" data-toggle-user-reviews-target='reviews'>
       <% reviews.each do |review| %>
         <div class='card bg-pink p-2 m-2'>
-          <p><%= review.user_reviewer.email %> dijo: </p>
+          <% reviewer_name = review.user_reviewer.nickname.nil? ? review.user_reviewer.email.split("@").first : review.user_reviewer.nickname %>
+          <p><%= reviewer_name %> dijo: </p>
           <p>Rating: <%= review.rating %> <i class="fa-solid fa-star"></i></p>
           <p>Comentario: <%= review.content %></p>
         </div>

--- a/app/views/deals/_status_item.html.erb
+++ b/app/views/deals/_status_item.html.erb
@@ -5,7 +5,11 @@
           <%= cl_image_tag item.photos.first.key, class: "img-fluid rounded-4 m-auto" %>
         <% end %>
         <div class="position-absolute bottom-0 text-center rounded-bottom-4 start-0 w-100" style="background-color: rgba(0, 0, 0, 0.4);">
-          <p><%= item.user.nickname %></p>
+          <%if !item.user.nickname.nil?%>
+            <p><%= item.user.nickname %></p>
+          <%else%>
+            <p><%= item.user.email.split("@").first %></p>
+          <%end%>
         </div>
       </div>
       <p class="title-fixed-height"><%= item.name %></p>

--- a/app/views/deals/show.html.erb
+++ b/app/views/deals/show.html.erb
@@ -19,8 +19,10 @@
       <span><%= user_requested_name %> ofrece <%= @deal.requested_item.name %></span>
     </div>
 
-    <div class="d-flex justify-content-between align-items-center">
-      <%= render 'deals/cancel', deal: @deal, class: 'btn btn-danger btn-sm' %>
+    <div class="d-flex justify-content-around align-items-center">
+      <%  if @deal.status == 'accepted' %>
+        <%= render 'deals/cancel', deal: @deal, class: 'btn btn-danger btn-sm'%>
+      <% end %>
       <%= link_to 'Ver Perfil', user_path(@deal.users.reject { |user| user.id == current_user.id }), class: 'btn btn-light btn-sm' %>
       <%= render 'items/chatroom', chatroom: @chatroom, user: @deal.users.reject { |user| user.id == current_user.id }, class: 'btn btn-light btn-sm' %>
     </div>

--- a/app/views/deals/show.html.erb
+++ b/app/views/deals/show.html.erb
@@ -9,7 +9,8 @@
   </div>
   <div class="col-12 col-md-7 bg-primary">
     <p class="text-end"><i class="fa-solid fa-location-dot mx-2"></i><%= @deal.user_offerer.address %></p>
-    <p class="text-end"><strong>Rating de <%= @reviewed_user.nickname %>: <%= @rating.nil? ? 'Sin reseñas' : @rating %> <i class="fa-solid fa-star"></i> </strong></p>
+        <% reviewed_user_name = !@reviewed_user.nickname.nil? ? @reviewed_user.email.split('@').first : @reviewed_user.nickname %>
+    <p class="text-end"><strong>Rating de <%= reviewed_user_name %>: <%= @rating.nil? ? 'Sin reseñas' : @rating %> <i class="fa-solid fa-star"></i> </strong></p>
     <div class="bg-pink p-3 m-3">
       <%if !@deal.user_offerer.nickname.nil?%>
         <span><%= @deal.user_offerer.nickname %> ofrece <%= @deal.offered_item.name %></span>

--- a/app/views/deals/show.html.erb
+++ b/app/views/deals/show.html.erb
@@ -11,10 +11,19 @@
     <p class="text-end"><i class="fa-solid fa-location-dot mx-2"></i><%= @deal.user_offerer.address %></p>
     <p class="text-end"><strong>Rating de <%= @reviewed_user.nickname %>: <%= @rating.nil? ? 'Sin reseñas' : @rating %> <i class="fa-solid fa-star"></i> </strong></p>
     <div class="bg-pink p-3 m-3">
-      <p><%= @deal.user_offerer.email %> ofrece <%= @deal.offered_item.name %></p>
-      <p>a cambio de <%= @deal.requested_item.name %> perteneciente a <%= @deal.user_requested.email %></p>
+      <%if !@deal.user_offerer.nickname.nil?%>
+        <span><%= @deal.user_offerer.nickname %> ofrece <%= @deal.offered_item.name %></span>
+      <%else%>
+        <span><%= @deal.user_offerer.email.split("@").first %> ofrece <%= @deal.offered_item.name %></span>
+      <%end%>
+      <br>
+      <%if !@deal.user_requested.nickname.nil?%>
+        <span><%= @deal.user_requested.nickname %> ofrece <%= @deal.requested_item.name %></span>
+      <%else%>
+        <span><%= @deal.user_requested.email.split("@").first %> ofrece <%= @deal.requested_item.name %></span>
+      <%end%>
     </div>
-    
+
     <div class="d-flex justify-content-between align-items-center">
       <%= render 'deals/cancel', deal: @deal, class: 'btn btn-danger btn-sm' %>
       <%= link_to 'Ver Perfil', user_path(@deal.users.reject { |user| user.id == current_user.id }), class: 'btn btn-light btn-sm' %>
@@ -25,4 +34,3 @@
     <% end %>
   </div>
 </div>
-

--- a/app/views/deals/show.html.erb
+++ b/app/views/deals/show.html.erb
@@ -9,20 +9,14 @@
   </div>
   <div class="col-12 col-md-7 bg-primary">
     <p class="text-end"><i class="fa-solid fa-location-dot mx-2"></i><%= @deal.user_offerer.address %></p>
-        <% reviewed_user_name = !@reviewed_user.nickname.nil? ? @reviewed_user.email.split('@').first : @reviewed_user.nickname %>
+    <% reviewed_user_name = @reviewed_user.nickname.nil? ? @reviewed_user.email.split('@').first : @reviewed_user.nickname %>
     <p class="text-end"><strong>Rating de <%= reviewed_user_name %>: <%= @rating.nil? ? 'Sin reseñas' : @rating %> <i class="fa-solid fa-star"></i> </strong></p>
     <div class="bg-pink p-3 m-3">
-      <%if !@deal.user_offerer.nickname.nil?%>
-        <span><%= @deal.user_offerer.nickname %> ofrece <%= @deal.offered_item.name %></span>
-      <%else%>
-        <span><%= @deal.user_offerer.email.split("@").first %> ofrece <%= @deal.offered_item.name %></span>
-      <%end%>
+      <%offerer_name = @deal.user_offerer.nickname.nil? ? @deal.user_offerer.email.split("@").first : @deal.user_offerer.nickname %>
+      <span><%= offerer_name %> ofrece <%= @deal.offered_item.name %></span>
       <br>
-      <%if !@deal.user_requested.nickname.nil?%>
-        <span><%= @deal.user_requested.nickname %> ofrece <%= @deal.requested_item.name %></span>
-      <%else%>
-        <span><%= @deal.user_requested.email.split("@").first %> ofrece <%= @deal.requested_item.name %></span>
-      <%end%>
+      <%user_requested_name = @deal.user_requested.nickname.nil? ? @deal.user_requested.email.split("@").first : @deal.user_requested.nickname %>
+      <span><%= user_requested_name %> ofrece <%= @deal.requested_item.name %></span>
     </div>
 
     <div class="d-flex justify-content-between align-items-center">

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -11,7 +11,8 @@
       <i class='text-dark'><%= message.created_at.strftime("%a %b %e at %l:%M %p") %></i>
       <p class='text-dark'><%= message.content %></p>
     <%else%>
-      <strong><%= message.user.nickname %></strong>
+      <% user_name = message.user.nickname.nil? ? message.user.email.split('@').first : message.user.nickname%>
+      <strong><%= user_name %></strong>
       <i><%= message.created_at.strftime("%a %b %e at %l:%M %p") %></i>
       <p><%= message.content %></p>
     <%end%>

--- a/app/views/offers/show.html.erb
+++ b/app/views/offers/show.html.erb
@@ -13,17 +13,11 @@
     <% reviewed_user_name = !@reviewed_user.nickname.nil? ? @reviewed_user.email.split('@').first : @reviewed_user.nickname %>
     <p class="text-end"><strong>Rating de <%= reviewed_user_name %>: <%= @rating.nil? ? 'Sin reseñas' : @rating %> <i class="fa-solid fa-star"></i></strong></p>
     <div class="bg-pink p-3 m-3">
-      <%if !@offer.user_offerer.nickname.nil?%>
-        <span><%= @offer.user_offerer.nickname %> ofrece <%= @offer.offered_item.name %></span>
-      <%else%>
-        <span><%= @offer.user_offerer.email.split("@").first %> ofrece <%= @offer.offered_item.name %></span>
-      <%end%>
+      <%offerer_name = @offer.user_offerer.nickname.nil? ? @offer.user_offerer.email.split("@").first : @offer.user_offerer.nickname %>
+      <span><%= offerer_name %> ofrece <%= @offer.offered_item.name %></span>
       <br>
-      <%if !@offer.user_requested.nickname.nil?%>
-        <span><%= @offer.user_requested.nickname %> ofrece <%= @offer.requested_item.name %></span>
-      <%else%>
-        <span><%= @offer.user_requested.email.split("@").first %> ofrece <%= @offer.requested_item.name %></span>
-      <%end%>
+      <%user_requested_name = @offer.user_requested.nickname.nil? ? @offer.user_requested.email.split("@").first : @offer.user_requested.nickname %>
+      <span><%= @offer.user_requested.nickname %> ofrece <%= @offer.requested_item.name %></span>
     </div>
     <div class='d-flex justify-content-around p-3'>
       <div class="d-flex align-items-center">

--- a/app/views/offers/show.html.erb
+++ b/app/views/offers/show.html.erb
@@ -10,7 +10,8 @@
     </div>
     <div class="col-12 col-md-7 bg-primary">
     <p class="text-end"><i class="fa-solid fa-location-dot mx-2"></i><%= @offer.user_offerer.address %></p>
-    <p class="text-end"><strong>Rating de <%= @reviewed_user.email %>: <%= @rating.nil? ? 'Sin reseñas' : @rating %> <i class="fa-solid fa-star"></i></strong></p>
+    <% reviewed_user_name = !@reviewed_user.nickname.nil? ? @reviewed_user.email.split('@').first : @reviewed_user.nickname %>
+    <p class="text-end"><strong>Rating de <%= reviewed_user_name %>: <%= @rating.nil? ? 'Sin reseñas' : @rating %> <i class="fa-solid fa-star"></i></strong></p>
     <div class="bg-pink p-3 m-3">
       <%if !@offer.user_offerer.nickname.nil?%>
         <span><%= @offer.user_offerer.nickname %> ofrece <%= @offer.offered_item.name %></span>

--- a/app/views/offers/show.html.erb
+++ b/app/views/offers/show.html.erb
@@ -12,8 +12,17 @@
     <p class="text-end"><i class="fa-solid fa-location-dot mx-2"></i><%= @offer.user_offerer.address %></p>
     <p class="text-end"><strong>Rating de <%= @reviewed_user.email %>: <%= @rating.nil? ? 'Sin reseñas' : @rating %> <i class="fa-solid fa-star"></i></strong></p>
     <div class="bg-pink p-3 m-3">
-      <p><%= @offer.user_offerer.email %> ofrece <%= @offer.offered_item.name %></p>
-      <p>a cambio de <%= @offer.requested_item.name %> perteneciente a <%= @offer.user_requested.email %></p>
+      <%if !@offer.user_offerer.nickname.nil?%>
+        <span><%= @offer.user_offerer.nickname %> ofrece <%= @offer.offered_item.name %></span>
+      <%else%>
+        <span><%= @offer.user_offerer.email.split("@").first %> ofrece <%= @offer.offered_item.name %></span>
+      <%end%>
+      <br>
+      <%if !@offer.user_requested.nickname.nil?%>
+        <span><%= @offer.user_requested.nickname %> ofrece <%= @offer.requested_item.name %></span>
+      <%else%>
+        <span><%= @offer.user_requested.email.split("@").first %> ofrece <%= @offer.requested_item.name %></span>
+      <%end%>
     </div>
     <div class='d-flex justify-content-around p-3'>
       <div class="d-flex align-items-center">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,8 +8,8 @@
         <div class="card-body">
           <div class="row">
             <div class="col-md-6">
-              <p class="lead"><strong>Nombre:</strong> <%= @user.nickname %></p>
-              <p class="lead"><strong>Email:</strong> <%= @user.nickname %></p>
+              <% user_name = @user.nickname.nil? ? @user.email.split("@").first : @user.nickname %>
+              <p class="lead"><strong>Nombre:</strong> <%= user_name %></p>
               <p class="lead"><strong>Rating: <%= @rating.nil? ? 'Sin reseñas' : @rating %> <i class="fa-solid fa-star"></i></strong></p>
               <p class="lead"><strong>Ubicación:</strong> <%= @user.address %></p>
               <p class="lead"><strong>Preferencias:</strong></p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -40,6 +40,7 @@
 
 <%= render 'deals/show_reviews', reviews: @reviews, reviewed_user: @user %>
 <div class='container'>
-  <h1>Productos de <%= @user.nickname %></h1>
+
+  <h1>Productos de <%= user_name %></h1>
   <%= render 'items/my_items', items: @items %>
 </div>


### PR DESCRIPTION
As per user's recommendations we choose to hide the personal emails. All communication should be by chat:

I ve added logic to display the nickname, and in case the user has no nickname, the first part of the email(e.g. juancarlos@gmail.com => juancarlos). This was changed in:
- deals index
- deal show
- offer show
- chatroom index
- chatroom show
- users show
- reviews

Email is only visible in the user's profile, only visible by him/her.

Also:
I find an issue in the deals show: canceled and completed deals where showing a cancel option. I added an if so that it is only showing this option for 'accepted' deals.
