### PR TITLE
added margin to the whole danger button

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -119,3 +119,7 @@ body {
 .form-check-input:checked {
   background-color: #777777
 }
+
+.btn-outline-danger {
+  margin: 10px;
+}


### PR DESCRIPTION
in the previous push I removed the margin of the button danger, so that the buttons were aligned and it worked. But I discovered that the buttons were too low. I correct that change with this push, see in pictures how it looks now:
<img width="928" alt="tbn with margin" src="https://github.com/nicow991/no_cash/assets/156020746/f98005f8-644b-43b5-9d10-24ae34967b8f">
<img width="926" alt="btn danger with margin" src="https://github.com/nicow991/no_cash/assets/156020746/34b2646b-d1f7-445a-837b-d781c24ad022">

